### PR TITLE
使用 mysql 数据库替换 h2 数据库

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
             <version>3.5.5</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.21</version>
+        </dependency>
+
 
 
     </dependencies>
@@ -137,9 +144,9 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>5.2.4</version>
                 <configuration>
-                    <url>jdbc:h2:file:D:\wb\my\fork\crawler\news</url>
-                    <user>root</user>
-                    <password>root123</password>
+                    <url>jdbc:mysql://192.168.10.10:3306/news?characterEncoding=utf-8</url>
+                    <user>homestead</user>
+                    <password>secret</password>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/github/mushanwb/Crawler.java
+++ b/src/main/java/com/github/mushanwb/Crawler.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 public class Crawler {
 
-    private CrawlerDao dao = new MyBatisCrawlerDao();
+    private CrawlerDao dao = new JdbcCrawlerDao();
 
     public static void main(String[] args) throws IOException, SQLException {
         new Crawler().run();

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -1,16 +1,16 @@
-create table NEWS(
+create table news(
     id bigint primary key auto_increment,
     title text,
     content text,
     url varchar(2000),
-    created_at timestamp,
-    modified_at timestamp
+    created_at timestamp default now(),
+    updated_at timestamp default now()
 );
 
-create table LINKS_ALREADY_PROCESSED(
+create table links_already_processed(
     link varchar(2000)
 );
 
-create table LINKS_TO_BE_PROCESSED(
+create table links_to_be_processed(
     link varchar(2000)
 );

--- a/src/main/resources/db/migration/V2__Init_data.sql
+++ b/src/main/resources/db/migration/V2__Init_data.sql
@@ -1,1 +1,1 @@
-insert into LINKS_TO_BE_PROCESSED ( LINK ) VALUES ( 'https://sina.cn' )
+insert into links_to_be_processed ( link ) VALUES ( 'https://sina.cn' )

--- a/src/main/resources/db/mybatis/MyMapper.xml
+++ b/src/main/resources/db/mybatis/MyMapper.xml
@@ -4,19 +4,19 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.github.mushanwb.MyMapper">
     <select id="selectNextAvailableLink" resultType="String">
-        SELECT LINK FROM LINKS_TO_BE_PROCESSED LIMIT 1
+        SELECT link FROM links_to_be_processed LIMIT 1
     </select>
 
     <delete id="deleteLink" parameterType="String">
-        DELETE FROM LINKS_TO_BE_PROCESSED WHERE LINK = #{LINK}
+        DELETE FROM links_to_be_processed WHERE link = #{link}
     </delete>
 
     <insert id="insertNews" parameterType="com.github.mushanwb.News">
-        INSERT INTO NEWS (TITLE, CONTENT, URL, CREATED_AT, MODIFIED_AT) values ( #{title}, #{content}, #{url}, now(), now() )
+        INSERT INTO news (title, content, url, created_at, updated_at) values ( #{title}, #{content}, #{url}, now(), now() )
     </insert>
 
     <select id="countLink" parameterType="String" resultType="int">
-        SELECT count(*) FROM LINKS_ALREADY_PROCESSED WHERE LINK = #{LINK}
+        SELECT count(*) FROM links_already_processed WHERE link = #{link}
     </select>
 
     <insert id="insertLink" parameterType="HashMap">
@@ -29,6 +29,6 @@
                 links_already_processed
             </otherwise>
         </choose>
-        ( LINK ) values ( #{link} )
+        ( link ) values ( #{link} )
     </insert>
 </mapper>

--- a/src/main/resources/db/mybatis/config.xml
+++ b/src/main/resources/db/mybatis/config.xml
@@ -7,10 +7,10 @@
         <environment id="development">
             <transactionManager type="JDBC"/>
             <dataSource type="POOLED">
-                <property name="driver" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:file:D:\wb\my\fork\crawler\news"/>
-                <property name="username" value="root"/>
-                <property name="password" value="root123"/>
+                <property name="driver" value="com.mysql.cj.jdbc.Driver"/>
+                <property name="url" value="jdbc:mysql://192.168.10.10:3306/news?characterEncoding=utf-8"/>
+                <property name="username" value="homestead"/>
+                <property name="password" value="secret"/>
             </dataSource>
         </environment>
     </environments>


### PR DESCRIPTION
在这个提交中,我将使用 mysql 数据库,
因此我在 pom.xml 文件中引入了 mysql 包
理论上我只需要更改 flywaydb 插件的配置和 mybatis 的 config.xml 文件的配置即可
但是由于之前使用是 h2 数据库,我不知道 mysql 数据库默认的设置表名不区分大小写
因此我需要将所有的表名都更改为小写,统一大小写
注意: mysql 数据库需要设置 utf-8 字符集,同时在连接 mysql 的时候也需要指定传输 utf-8